### PR TITLE
Push other versions of the image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,23 @@ jobs:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      
+      # Push another version of the image which has a label
+      - name: Build and push Docker image
+        id: build-and-push-base-label
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:base-label
+          labels: org.opencontainers.image.base.name=alpine:latest
+
+      # Push another version of the image which has an annotation
+      - name: Build and push Docker image
+        id: build-and-push-base-annotation
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:base-annotation
+          annotations: org.opencontainers.image.base.name=alpine:latest


### PR DESCRIPTION
Updates the build workflow so that other versions of the image are pushed that includes base name as a label and annotation.